### PR TITLE
Added support for iOS 7

### DIFF
--- a/SimulatorRemoteNotifications/UIApplication+SimulatorRemoteNotifications.m
+++ b/SimulatorRemoteNotifications/UIApplication+SimulatorRemoteNotifications.m
@@ -53,7 +53,10 @@ static int __port = PORT;
 		} else if (![dict isKindOfClass:[NSDictionary class]]) {
 			NSLog(@"SimulatorRemoteNotification: message error (not a dictionary)");
 		} else {
-			if ([self.delegate respondsToSelector:@selector(application:didReceiveRemoteNotification:)]) {
+            if ([self.delegate respondsToSelector:@selector(application:didReceiveRemoteNotification:fetchCompletionHandler:)]) {
+                [self.delegate application:self didReceiveRemoteNotification:dict fetchCompletionHandler:^(UIBackgroundFetchResult result) {}];
+			}
+			else if ([self.delegate respondsToSelector:@selector(application:didReceiveRemoteNotification:)]) {
 					[self.delegate application:self didReceiveRemoteNotification:dict];
 			}
 		}


### PR DESCRIPTION
As outlined in:

https://developer.apple.com/library/ios/documentation/uikit/reference/UIApplicationDelegate_Protocol/Reference/Reference.html#//apple_ref/occ/intfm/UIApplicationDelegate/application:didReceiveRemoteNotification:

> If your delegate also implements the application:didReceiveRemoteNotification:fetchCompletionHandler: method, the app object calls that method instead of this one.
