### PR TITLE
Enabled didReceiveRemoteNotification: for iOS 7 apps that use old API

### DIFF
--- a/SimulatorRemoteNotifications/UIApplication+SimulatorRemoteNotifications.m
+++ b/SimulatorRemoteNotifications/UIApplication+SimulatorRemoteNotifications.m
@@ -57,11 +57,10 @@ static int __port = PORT;
                 if ([self.delegate respondsToSelector:@selector(application:didReceiveRemoteNotification:fetchCompletionHandler:)]) {
                     [self.delegate application:self didReceiveRemoteNotification:dict fetchCompletionHandler:^(UIBackgroundFetchResult result) {}];
                 }
-            #else
-                if ([self.delegate respondsToSelector:@selector(application:didReceiveRemoteNotification:)]) {
-                    [self.delegate application:self didReceiveRemoteNotification:dict];
-                }
             #endif
+            if ([self.delegate respondsToSelector:@selector(application:didReceiveRemoteNotification:)]) {
+                [self.delegate application:self didReceiveRemoteNotification:dict];
+            }
 		}
 	});
     dispatch_source_set_cancel_handler(input_src,  ^{


### PR DESCRIPTION
It seems that application:didReceiveRemoteNotification: should be called even if the app is running in iOS 7 because not all apps will have migrated to use the newer method that has a completion block.
