### PR TITLE
Disabling automaticQuoteSubstitutionEnabled for payloadTextView in the iOS Simulator Notifications Mac app.

### DIFF
--- a/iOS Simulator Notifications/ACAppDelegate.m
+++ b/iOS Simulator Notifications/ACAppDelegate.m
@@ -26,6 +26,8 @@ static NSString * const ACAppDelegatePayloadUserDefaultsKey = @"ACAppDelegatePay
             self.payloadTextView.string = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
         }
     }
+    
+    self.payloadTextView.automaticQuoteSubstitutionEnabled = NO;
 }
 
 #pragma mark - Actions


### PR DESCRIPTION
Currently the NSTextView replaces any input quotes with quotes that break the JSON validation.

So `"key":"value"` becomes `“key”:”value”`. This just disables that in `applicationDidFinishLaunching`.