### PR TITLE
4k buffer for modern iOS versions

### DIFF
--- a/SimulatorRemoteNotifications/ACSimulatorRemoteNotificationsService.m
+++ b/SimulatorRemoteNotifications/ACSimulatorRemoteNotificationsService.m
@@ -21,7 +21,7 @@
  * udp max length is 65,507 bytes
  * apns max length is 256 bytes
  */
-static const NSInteger SimulatorRemoteNotificationsServiceBufferLength = 512;
+static const NSInteger SimulatorRemoteNotificationsServiceBufferLength = 4096;
 static const NSInteger SimulatorRemoteNotificationsServiceDefaultPort = 9930;
 static NSString * const SimulatorRemoteNotificationsServiceDefaultHost = @"127.0.0.1";
 

--- a/SimulatorRemoteNotifications/UIApplication+SimulatorRemoteNotifications.m
+++ b/SimulatorRemoteNotifications/UIApplication+SimulatorRemoteNotifications.m
@@ -22,7 +22,7 @@
  * udp max length is 65,507 bytes
  * apns max length is 256 bytes
  */
-static const NSInteger SimulatorRemoteNotificationsBufferLength = 512;
+static const NSInteger SimulatorRemoteNotificationsBufferLength = 4096;
 static const NSInteger SimulatorRemoteNotificationsDefaultPort = 9930;
 
 


### PR DESCRIPTION
This PR updates the notification buffer size to 4k matching current [documentation](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification) modern http/2 non voip based notification payload sizes.

We hit the previous size limit during development/testing of our app, and this patch fixed the issue.